### PR TITLE
adding support to publish as docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Ignore node modules
+node_modules
+
+# Ignore logs
+npm-debug.log
+yarn-error.log
+
+# Ignore OS specific files
+.DS_Store
+Thumbs.db
+
+# Ignore Editor files
+*.swp
+*.swo
+*.swp.*
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+USER node
+
+EXPOSE 3000
+
+ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
Adding dockerfile to support future docker image publishing.

`Docker Build`
```sh
docker build -t openapi-autospec . 
```
`Docker Run`
```sh
docker run -it --rm openapi-autospec --portTo 3000 --portFrom 3001 --filePath spec.json
```

<img width="978" alt="image" src="https://github.com/Adawg4/openapi-autospec/assets/18288720/a35f0688-4ac8-4f76-aa07-1d12c20964e9">
